### PR TITLE
Fix favicon path on subpages

### DIFF
--- a/concepts/ohms_law.html
+++ b/concepts/ohms_law.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/concepts/what_is_electrical_engineering.html
+++ b/concepts/what_is_electrical_engineering.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question1.html
+++ b/questions/question1.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question10.html
+++ b/questions/question10.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question11.html
+++ b/questions/question11.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question12.html
+++ b/questions/question12.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question13.html
+++ b/questions/question13.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question14.html
+++ b/questions/question14.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question15.html
+++ b/questions/question15.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question16.html
+++ b/questions/question16.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question17.html
+++ b/questions/question17.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question18.html
+++ b/questions/question18.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question19.html
+++ b/questions/question19.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question2.html
+++ b/questions/question2.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question20.html
+++ b/questions/question20.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question21.html
+++ b/questions/question21.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question22.html
+++ b/questions/question22.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question3.html
+++ b/questions/question3.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question4.html
+++ b/questions/question4.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question5.html
+++ b/questions/question5.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question6.html
+++ b/questions/question6.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question7.html
+++ b/questions/question7.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question8.html
+++ b/questions/question8.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />

--- a/questions/question9.html
+++ b/questions/question9.html
@@ -13,7 +13,7 @@
   <meta name="author" content="" />
 
   <title>InterviewAware</title>
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
 
   <!-- bootstrap core css -->
   <link rel="stylesheet" type="text/css" href="../css/bootstrap.css" />


### PR DESCRIPTION
## Summary
- fix broken favicon links in questions and concept subpages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e60fbb488320902025f3fed029a6