### PR TITLE
feat: refresh landing colors and add dynamic tagline

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,14 +5,24 @@ body {
 }
 
 :root {
-  /*--main: #1cbbb4;*/
-  /*--main: #FFFCF7;*/
-  --header: #0E2841;
-  --main: #F5EFE1;
-  /*--secondary: #0E2841;*/
-  --secondary: whitesmoke;
-  --textcolor: black;
-  --hovercolor: #1cbbb4;
+  /* Updated color scheme */
+  --header: #0D1B2A;
+  --main: #F9FAFB;
+  --secondary: #FFFFFF;
+  --textcolor: #0D1B2A;
+  --hovercolor: #00BFA6;
+  --accent: #00BFA6;
+}
+
+/* utility classes for new theme */
+.accent-text {
+  color: var(--accent);
+}
+
+.dynamic-message {
+  color: var(--accent);
+  font-weight: 600;
+  min-height: 1.5em;
 }
 
 /* table section */
@@ -692,7 +702,7 @@ a:focus {
 .slider_section .detail-box .btn-box .btn-1 {
   display: inline-block;
   padding: 10px 0;
-  background-color: #ff4f5a;
+  background-color: var(--accent);
   color: var(--textcolor);
   -webkit-transition: all 0.3s;
   transition: all 0.3s;
@@ -702,8 +712,8 @@ a:focus {
 
 .slider_section .detail-box .btn-box .btn-1:hover {
   background-color: transparent;
-  border-color: #ff4f5a;
-  color: #ff4f5a;
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .slider_section .detail-box .btn-box .btn-2 {
@@ -765,7 +775,7 @@ a:focus {
 
 .slider_section .carousel_btn-container .carousel-control-prev:hover,
 .slider_section .carousel_btn-container .carousel-control-next:hover {
-  background-color: #ff4f5a;
+  background-color: var(--accent);
 }
 
 .slider_section .carousel_btn-container .carousel-control-prev {
@@ -828,7 +838,7 @@ a:focus {
 .experience_section .detail-box .btn-box .btn-1 {
   display: inline-block;
   padding: 10px 0;
-  background-color: #ff4f5a;
+  background-color: var(--accent);
   color: var(--textcolor);
   -webkit-transition: all 0.3s;
   transition: all 0.3s;
@@ -838,8 +848,8 @@ a:focus {
 
 .experience_section .detail-box .btn-box .btn-1:hover {
   background-color: transparent;
-  border-color: #ff4f5a;
-  color: #ff4f5a;
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .experience_section .detail-box .btn-box .btn-2 {
@@ -942,7 +952,7 @@ a:focus {
 .about_section .detail-box a {
   display: inline-block;
   padding: 10px 45px;
-  background-color: #ff4f5a;
+  background-color: var(--accent);
   color: var(--textcolor);
   -webkit-transition: all 0.3s;
   transition: all 0.3s;
@@ -953,8 +963,8 @@ a:focus {
 
 .about_section .detail-box a:hover {
   background-color: transparent;
-  border-color: #ff4f5a;
-  color: #ff4f5a;
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .freelance_section .row {
@@ -1002,7 +1012,7 @@ a:focus {
 
 .freelance_section .tab_container .t-link-box .detail-box h5 {
   font-weight: bold;
-  color: #ff4f5a;
+  color: var(--accent);
 }
 
 .freelance_section .tab_container .t-link-box .detail-box h3 {
@@ -1170,7 +1180,7 @@ a:focus {
 .info_section .info_form form button {
   display: inline-block;
   padding: 8px 40px;
-  background-color: #ff4f5a;
+  background-color: var(--accent);
   color: var(--textcolor);
   -webkit-transition: all 0.3s;
   transition: all 0.3s;
@@ -1184,8 +1194,8 @@ a:focus {
 
 .info_section .info_form form button:hover {
   background-color: transparent;
-  border-color: #ff4f5a;
-  color: #ff4f5a;
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .info_section .info_contact .link-box {

--- a/css/style.scss
+++ b/css/style.scss
@@ -1,8 +1,8 @@
-$white: #ffffff;
-$black: #252525;
-$primary1: #1cbbb4;
-$primary2: #1a2e35;
-$btnColor: #ff4f5a;
+$white: #FFFFFF;
+$black: #0D1B2A;
+$primary1: #00BFA6;
+$primary2: #0D1B2A;
+$btnColor: #00BFA6;
 
 @mixin main-font {
   font-family: 'Poppins', sans-serif;

--- a/index.html
+++ b/index.html
@@ -96,12 +96,13 @@
           <div class="carousel-item active">
             <div class="container-fluid">
               <div class="row">
-                <div class="col-md-5 offset-md-1" style="background-color: whitesmoke;">
+                <div class="col-md-5 offset-md-1" style="background-color: var(--secondary);">
                   <div class="detail-box">
                     <h1>
                       Technical Engineering Interview Preparation, <br>
-                      In One, Easy Source - <span style="color:red;">FREE Today!</span>
+                      In One, Easy Source - <span class="accent-text">FREE Today!</span>
                     </h1>
+                    <h2 class="dynamic-message"><span id="dynamic-tagline"></span></h2>
                     <ul>
                       <li>Verified <b>interview questions and answers</b> created by interviewers working in the largest tech companies (Apple, Google, SpaceX, NVIDIA, etc.) </li>
                       <li>Study for your toughest engineering interviews</li>
@@ -121,7 +122,7 @@
                   </div>
                 </div>
                 <div class="offset-md-1 col-md-4 img-container">
-                  <div class="img-box" style="background-color: #F5EFE1;">
+                  <div class="img-box" style="background-color: var(--main);">
                     <img src="images/slider-img.png" alt="">
                   </div>
                 </div>

--- a/js/custom.js
+++ b/js/custom.js
@@ -39,3 +39,20 @@ function check () {
         textincorrect.classList.add("displayanswer")
     }
 }
+
+// rotating hero tagline
+document.addEventListener('DOMContentLoaded', function () {
+  var tagline = document.getElementById('dynamic-tagline');
+  if (!tagline) return;
+  var messages = [
+    'Practice real interview questions',
+    'Study with industry professionals',
+    'Get hired by top companies'
+  ];
+  var i = 0;
+  tagline.textContent = messages[i];
+  setInterval(function () {
+    i = (i + 1) % messages.length;
+    tagline.textContent = messages[i];
+  }, 3000);
+});


### PR DESCRIPTION
## Summary
- redesign site palette with teal accent variables
- add animated tagline on hero section for a more dynamic landing page
- update SCSS variables to match new theme

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890e9c258b88320bc9c73efda64f35c