### PR TITLE
Replace AI interviewer with hardware quiz

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.github/workflows/openai.yml
+++ b/.github/workflows/openai.yml
@@ -1,0 +1,26 @@
+name: Run OpenAI Node Script
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-openai:
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run OpenAI script
+        run: node scripts/openai-test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/about.html
+++ b/about.html
@@ -68,6 +68,8 @@
             <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
           </div>
         </div>
+        <a href="interview.html" class="text-gray-300 hover:text-white transition-colors">Interview Quiz</a>
+        <a href="ai.html" class="text-gray-300 hover:text-white transition-colors">AI Interviewer</a>
       </div>
       <a href="https://forms.gle/8aHq2fjXJQZP2PDN8" class="hidden md:inline-block rounded-full bg-accent-blue text-white px-5 py-2 font-medium hover:bg-opacity-80 transition">Sign Up</a>
     </div>

--- a/ai.html
+++ b/ai.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>InterviewAware</title>
+  <title>AI Interviewer - InterviewAware</title>
   <link rel="icon" type="image/x-icon" href="images/favicon.ico">
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -21,24 +21,12 @@
               sage: '#84cc16',
               gold: '#fcd34d'
             }
-          },
-          keyframes: {
-            'fade-in-up': {
-              '0%': { opacity: 0, transform: 'translateY(1rem)' },
-              '100%': { opacity: 1, transform: 'translateY(0)' }
-            }
-          },
-          animation: {
-            'fade-in-up': 'fade-in-up 1s ease-out forwards'
           }
         }
       }
     }
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=Space+Grotesk:wght@400;700&display=swap" rel="stylesheet">
-  <style>
-    body { @apply bg-[#0a0a0a] text-gray-300 font-sans; }
-  </style>
 </head>
 <body class="bg-[#0a0a0a] text-gray-300">
   <nav id="nav" class="fixed top-0 left-0 w-full z-50 transition-all duration-500">
@@ -74,65 +62,72 @@
     </div>
   </nav>
 
-  <main class="pt-32 max-w-6xl mx-auto px-6">
-    <h1 class="text-4xl font-bold text-white mb-8 font-display">Electrical Engineering Interview Questions</h1>
-    <div class="overflow-x-auto">
-      <table class="w-full text-left">
-        <thead>
-          <tr class="text-gray-400 border-b border-gray-700">
-            <th class="px-4 py-3 font-semibold">Title</th>
-            <th class="px-4 py-3 font-semibold">Company</th>
-            <th class="px-4 py-3 font-semibold">Topic</th>
-            <th class="px-4 py-3 font-semibold">Difficulty</th>
-          </tr>
-        </thead>
-        <tbody id="question-body" class="divide-y divide-gray-800"></tbody>
-      </table>
+  <main class="pt-24 max-w-3xl mx-auto px-6">
+    <h1 class="text-4xl font-bold text-white mb-6 font-display">AI Interviewer</h1>
+    <div id="chat" class="space-y-4 mb-4"></div>
+    <div class="flex gap-2">
+      <input id="message" class="flex-grow p-2 rounded bg-gray-800 text-white" placeholder="Type your answer..." />
+      <button id="sendBtn" class="px-4 py-2 bg-accent-blue text-white rounded">Send</button>
     </div>
   </main>
 
-  <footer class="py-12 bg-black text-center text-sm text-gray-500 mt-24">© 2024 InterviewAware. All rights reserved.</footer>
-
   <script>
-    const questions = [
+    const chat = document.getElementById('chat');
+    const messageInput = document.getElementById('message');
+    const sendBtn = document.getElementById('sendBtn');
+    let messages = [
       {
-        title: "Ohm’s Law - Calculating Current",
-        company: "Intel",
-        topic: "Circuit Theory",
-        difficulty: "Easy",
-        link: "questions/question1.html"
-      },
-      {
-        title: "Describe Voltage Regulation",
-        company: "Apple",
-        topic: "Power Electronics",
-        difficulty: "Easy",
-        link: "questions/question2.html"
+        role: 'system',
+        content: 'You are a hardware engineering interviewer. Ask the user one multiple-choice question at a time. After the user responds, tell them if they are correct and briefly explain before asking the next question.'
       }
     ];
 
-    const tbody = document.getElementById('question-body');
+    function appendMessage(role, text) {
+      const div = document.createElement('div');
+      div.className = role === 'user' ? 'text-right' : 'text-left';
+      div.innerHTML = `<span class="block px-3 py-2 rounded ${role === 'user' ? 'bg-accent-blue text-white' : 'bg-gray-800 text-gray-100'}">${text}</span>`;
+      chat.appendChild(div);
+      chat.scrollTop = chat.scrollHeight;
+    }
 
-    questions.forEach(q => {
-      const tr = document.createElement('tr');
-      tr.className = 'hover:bg-gray-800 rounded transition';
-      tr.innerHTML = `
-        <td class="px-4 py-4 font-semibold text-white"><a href="${q.link}" class="hover:text-accent-blue">${q.title}</a></td>
-        <td class="px-4 py-4">${q.company}</td>
-        <td class="px-4 py-4">${q.topic}</td>
-        <td class="px-4 py-4">${q.difficulty}</td>
-      `;
-      tbody.appendChild(tr);
+    async function sendMessage() {
+      const content = messageInput.value.trim();
+      if (!content) return;
+      appendMessage('user', content);
+      messages.push({ role: 'user', content });
+      messageInput.value = '';
+      sendBtn.disabled = true;
+
+      const res = await fetch('/api/interviewer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages })
+      });
+      const data = await res.json();
+      const reply = data.choices[0].message.content.trim();
+      messages.push({ role: 'assistant', content: reply });
+      appendMessage('assistant', reply);
+      sendBtn.disabled = false;
+      messageInput.focus();
+    }
+
+    sendBtn.addEventListener('click', sendMessage);
+    messageInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') sendMessage();
     });
 
-    const navEl = document.getElementById('nav');
-    window.addEventListener('scroll', () => {
-      if (window.scrollY > 10) {
-        navEl.classList.add('bg-black/70','backdrop-blur');
-      } else {
-        navEl.classList.remove('bg-black/70','backdrop-blur');
-      }
-    });
+    // Get the first question
+    (async () => {
+      const res = await fetch('/api/interviewer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages })
+      });
+      const data = await res.json();
+      const first = data.choices[0].message.content.trim();
+      messages.push({ role: 'assistant', content: first });
+      appendMessage('assistant', first);
+    })();
   </script>
 </body>
 </html>

--- a/ai.html
+++ b/ai.html
@@ -66,7 +66,7 @@
     <h1 class="text-4xl font-bold text-white mb-6 font-display">AI Interviewer</h1>
     <div id="chat" class="space-y-4 mb-4"></div>
     <div class="flex gap-2">
-      <input id="message" class="flex-grow p-2 rounded bg-gray-800 text-white" placeholder="Type your answer..." />
+      <input id="message" class="flex-grow p-2 rounded bg-gray-800 text-white" placeholder="Type your response..." />
       <button id="sendBtn" class="px-4 py-2 bg-accent-blue text-white rounded">Send</button>
     </div>
   </main>
@@ -78,7 +78,7 @@
     let messages = [
       {
         role: 'system',
-        content: 'You are a hardware engineering interviewer. Ask the user one multiple-choice question at a time. After the user responds, tell them if they are correct and briefly explain before asking the next question.'
+        content: `You are a hardware engineering interviewer. Start by asking, "Which role are you interviewing for today?" After the user provides a role, generate three multiple-choice hardware engineering questions, delivering them one at a time. For each question, provide four options labeled A-D. When the user answers, respond with whether they are correct, give the correct answer and a brief explanation, then move to the next question. After three questions, give a summary breaking down correct versus incorrect answers and highlight the user's strengths and weaknesses. End the interview after the summary.`
       }
     ];
 

--- a/concept.html
+++ b/concept.html
@@ -68,6 +68,8 @@
             <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
           </div>
         </div>
+        <a href="interview.html" class="text-gray-300 hover:text-white transition-colors">Interview Quiz</a>
+        <a href="ai.html" class="text-gray-300 hover:text-white transition-colors">AI Interviewer</a>
       </div>
       <a href="https://forms.gle/8aHq2fjXJQZP2PDN8" class="hidden md:inline-block rounded-full bg-accent-blue text-white px-5 py-2 font-medium hover:bg-opacity-80 transition">Sign Up</a>
     </div>

--- a/concepts/ohms_law.html
+++ b/concepts/ohms_law.html
@@ -68,6 +68,8 @@
             <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
           </div>
         </div>
+      <a href="../interview.html" class="text-gray-300 hover:text-white transition-colors">Interview Quiz</a>
+      <a href="../ai.html" class="text-gray-300 hover:text-white transition-colors">AI Interviewer</a>
       </div>
       <a href="https://forms.gle/8aHq2fjXJQZP2PDN8" class="hidden md:inline-block rounded-full bg-accent-blue text-white px-5 py-2 font-medium hover:bg-opacity-80 transition">Sign Up</a>
     </div>

--- a/concepts/what_is_electrical_engineering.html
+++ b/concepts/what_is_electrical_engineering.html
@@ -68,6 +68,8 @@
             <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
           </div>
         </div>
+        <a href="../interview.html" class="text-gray-300 hover:text-white transition-colors">Interview Quiz</a>
+        <a href="../ai.html" class="text-gray-300 hover:text-white transition-colors">AI Interviewer</a>
       </div>
       <a href="https://forms.gle/8aHq2fjXJQZP2PDN8" class="hidden md:inline-block rounded-full bg-accent-blue text-white px-5 py-2 font-medium hover:bg-opacity-80 transition">Sign Up</a>
     </div>

--- a/index.html
+++ b/index.html
@@ -60,19 +60,21 @@
           <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
         </div>
       </div>
-      <div class="relative group">
-        <button class="flex items-center text-gray-300 hover:text-white transition-colors">Interview Questions<svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg></button>
-        <div class="absolute left-0 mt-2 w-64 bg-black/80 backdrop-blur rounded-md opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
-          <a href="content.html" class="block px-4 py-2 text-gray-300 hover:bg-accent-blue/20 hover:text-white">Electrical Engineering</a>
-          <span class="block px-4 py-2 text-gray-500">Mechanical Engineering (coming soon)</span>
-          <span class="block px-4 py-2 text-gray-500">Civil Engineering (coming soon)</span>
-          <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
+        <div class="relative group">
+          <button class="flex items-center text-gray-300 hover:text-white transition-colors">Interview Questions<svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg></button>
+          <div class="absolute left-0 mt-2 w-64 bg-black/80 backdrop-blur rounded-md opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+            <a href="content.html" class="block px-4 py-2 text-gray-300 hover:bg-accent-blue/20 hover:text-white">Electrical Engineering</a>
+            <span class="block px-4 py-2 text-gray-500">Mechanical Engineering (coming soon)</span>
+            <span class="block px-4 py-2 text-gray-500">Civil Engineering (coming soon)</span>
+            <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
+          </div>
         </div>
+        <a href="interview.html" class="text-gray-300 hover:text-white transition-colors">Interview Quiz</a>
+        <a href="ai.html" class="text-gray-300 hover:text-white transition-colors">AI Interviewer</a>
       </div>
+      <a href="https://forms.gle/8aHq2fjXJQZP2PDN8" class="hidden md:inline-block rounded-full bg-accent-blue text-white px-5 py-2 font-medium hover:bg-opacity-80 transition">Sign Up</a>
     </div>
-    <a href="https://forms.gle/8aHq2fjXJQZP2PDN8" class="hidden md:inline-block rounded-full bg-accent-blue text-white px-5 py-2 font-medium hover:bg-opacity-80 transition">Sign Up</a>
-  </div>
-</nav>
+  </nav>
 
 
   <!-- Hero Section -->

--- a/interview.html
+++ b/interview.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Interview Quiz - InterviewAware</title>
+  <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'sans-serif'],
+            display: ['Space Grotesk', 'sans-serif']
+          },
+          colors: {
+            accent: {
+              blue: '#3b82f6',
+              amber: '#f59e0b',
+              sage: '#84cc16',
+              gold: '#fcd34d'
+            }
+          },
+          keyframes: {
+            'fade-in-up': {
+              '0%': { opacity: 0, transform: 'translateY(1rem)' },
+              '100%': { opacity: 1, transform: 'translateY(0)' }
+            }
+          },
+          animation: {
+            'fade-in-up': 'fade-in-up 1s ease-out forwards'
+          }
+        }
+      }
+    }
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=Space+Grotesk:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body { @apply bg-[#0a0a0a] text-gray-300 font-sans; }
+  </style>
+</head>
+<body class="bg-[#0a0a0a] text-gray-300">
+  <nav id="nav" class="fixed top-0 left-0 w-full z-50 transition-all duration-500">
+    <div class="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
+      <a href="index.html" class="flex items-center space-x-2">
+        <img src="images/samplelogo.png" class="h-8 w-8" alt="" />
+        <span class="font-display text-white text-xl">InterviewAware</span>
+      </a>
+      <div class="hidden md:flex items-center space-x-6">
+        <a href="about.html" class="text-gray-300 hover:text-white transition-colors">About</a>
+        <div class="relative group">
+          <button class="flex items-center text-gray-300 hover:text-white transition-colors">Concepts<svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg></button>
+          <div class="absolute left-0 mt-2 w-56 bg-black/80 backdrop-blur rounded-md opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+            <a href="concept.html" class="block px-4 py-2 text-gray-300 hover:bg-accent-blue/20 hover:text-white">Electrical Engineering</a>
+            <span class="block px-4 py-2 text-gray-500">Mechanical Engineering (coming soon)</span>
+            <span class="block px-4 py-2 text-gray-500">Civil Engineering (coming soon)</span>
+            <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
+          </div>
+        </div>
+        <div class="relative group">
+          <button class="flex items-center text-gray-300 hover:text-white transition-colors">Interview Questions<svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg></button>
+          <div class="absolute left-0 mt-2 w-64 bg-black/80 backdrop-blur rounded-md opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+            <a href="content.html" class="block px-4 py-2 text-gray-300 hover:bg-accent-blue/20 hover:text-white">Electrical Engineering</a>
+            <span class="block px-4 py-2 text-gray-500">Mechanical Engineering (coming soon)</span>
+            <span class="block px-4 py-2 text-gray-500">Civil Engineering (coming soon)</span>
+            <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
+          </div>
+        </div>
+        <a href="interview.html" class="text-gray-300 hover:text-white transition-colors">Interview Quiz</a>
+        <a href="ai.html" class="text-gray-300 hover:text-white transition-colors">AI Interviewer</a>
+      </div>
+      <a href="https://forms.gle/8aHq2fjXJQZP2PDN8" class="hidden md:inline-block rounded-full bg-accent-blue text-white px-5 py-2 font-medium hover:bg-opacity-80 transition">Sign Up</a>
+    </div>
+  </nav>
+  <main class="pt-32 max-w-3xl mx-auto px-6">
+    <h1 class="text-4xl font-bold text-white mb-6 font-display">Interview Quiz</h1>
+    <p class="mb-6">Practice hardware engineering interview questions.</p>
+    <div id="start-screen" class="text-center">
+      <button id="start-btn" class="bg-gradient-to-r from-accent-blue to-accent-amber text-black font-semibold px-6 py-3 rounded-lg hover:opacity-90 transition">Start Quiz</button>
+    </div>
+    <div id="quiz" class="hidden">
+      <div id="progress" class="mb-4 text-sm text-gray-400"></div>
+      <div id="question-box" class="bg-black/40 p-6 rounded-lg shadow mb-4">
+        <div id="question-text" class="font-semibold mb-4"></div>
+        <div id="choices" class="space-y-3"></div>
+        <div id="explanation" class="mt-4 text-sm hidden"></div>
+      </div>
+      <button id="next-btn" class="bg-accent-blue text-white px-4 py-2 rounded hover:bg-opacity-80 transition hidden">Next Question</button>
+    </div>
+    <div id="result" class="hidden text-center">
+      <h2 class="text-2xl font-display text-white mb-4">Quiz Complete!</h2>
+      <p id="score" class="mb-4"></p>
+      <button id="restart-btn" class="bg-accent-amber text-black px-4 py-2 rounded hover:bg-opacity-80 transition">Restart</button>
+    </div>
+  </main>
+  <footer class="py-12 bg-black text-center text-sm text-gray-500 mt-24">© 2024 InterviewAware. All rights reserved.</footer>
+  <script>
+    const navEl = document.getElementById('nav');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 10) {
+        navEl.classList.add('bg-black/70','backdrop-blur');
+      } else {
+        navEl.classList.remove('bg-black/70','backdrop-blur');
+      }
+    });
+
+    const QUESTIONS = [
+      {
+        question: "What is the primary function of a differential signal pair like in PCIe or Ethernet?",
+        choices: [
+          "To transmit data with high noise immunity by using two complementary signals",
+          "To reduce power consumption in low-speed logic",
+          "To isolate analog and digital circuits completely",
+          "To increase bus capacitance for decoupling"
+        ],
+        answer: 0,
+        explanation: "Differential signals offer superior noise immunity and are used in high-speed interfaces like PCIe and Ethernet."
+      },
+      {
+        question: "Which instrument is best suited to analyze a high-speed signal’s rise time and overshoot?",
+        choices: ["Oscilloscope", "Multimeter", "Power supply", "Logic analyzer"],
+        answer: 0,
+        explanation: "Oscilloscopes visualize fast transients and timing characteristics of high-speed digital signals."
+      },
+      {
+        question: "What does DDR stand for in memory interfaces?",
+        choices: ["Double Data Rate", "Dynamic Drive Regulation", "Digital Direct Relay", "Distributed Device Routing"],
+        answer: 0,
+        explanation: "DDR transfers data on both rising and falling clock edges, doubling the throughput."
+      },
+      {
+        question: "What is the role of a decoupling capacitor in high-speed PCB design?",
+        choices: [
+          "To provide local charge storage and filter high-frequency noise on power lines",
+          "To step up voltage for logic gates",
+          "To generate clock signals for high-speed buses",
+          "To delay address decoding for memory"
+        ],
+        answer: 0,
+        explanation: "Decoupling capacitors stabilize voltage levels and suppress noise during fast transitions."
+      },
+      {
+        question: "Which of the following is a high-speed serial bus used in computing systems?",
+        choices: ["PCIe", "UART", "I2C", "PWM"],
+        answer: 0,
+        explanation: "PCIe (Peripheral Component Interconnect Express) is a high-speed interface used for connecting processors to peripherals."
+      },
+      {
+        question: "What is typically used to terminate high-speed transmission lines and prevent reflections?",
+        choices: [
+          "Series or parallel resistors matched to the characteristic impedance",
+          "Capacitive dividers",
+          "Crystal oscillators",
+          "Voltage regulators"
+        ],
+        answer: 0,
+        explanation: "Proper termination minimizes signal reflections that cause distortion in high-speed designs."
+      },
+      {
+        question: "Which layer in a multi-layer PCB is commonly used for distributing power?",
+        choices: ["Power plane", "Top signal layer", "Solder mask layer", "Silkscreen"],
+        answer: 0,
+        explanation: "Power planes ensure stable power delivery and help reduce impedance in high-performance PCBs."
+      },
+      {
+        question: "Why is trace length matching important in high-speed parallel buses?",
+        choices: [
+          "To ensure signals arrive simultaneously and avoid timing skew",
+          "To reduce power dissipation",
+          "To minimize physical board size",
+          "To isolate ground noise"
+        ],
+        answer: 0,
+        explanation: "Matched lengths reduce timing mismatch between data lines and clock/reference signals."
+      },
+      {
+        question: "Which unit is commonly used to specify high-speed signal data rates?",
+        choices: ["Gbps (Gigabits per second)", "Hz (Hertz)", "Volts", "Ohms"],
+        answer: 0,
+        explanation: "Gbps measures data rate, especially in high-speed digital links like PCIe or Ethernet."
+      },
+      {
+        question: "What does 'eye diagram' represent in high-speed signal testing?",
+        choices: [
+          "A composite waveform showing signal integrity and timing margin",
+          "A spectrum of frequency harmonics",
+          "A measure of thermal performance",
+          "A visual test for circuit boards under x-rays"
+        ],
+        answer: 0,
+        explanation: "Eye diagrams visualize timing and voltage margin in high-speed signals by overlapping multiple bits."
+      },
+      {
+        question: "Which of these tools is typically used to validate power supply ripple in hardware designs?",
+        choices: ["Oscilloscope", "Logic analyzer", "Vector network analyzer", "Pulse generator"],
+        answer: 0,
+        explanation: "Oscilloscopes measure ripple, transients, and noise in power delivery networks."
+      },
+      {
+        question: "What is a common cause of signal integrity issues in high-speed PCB designs?",
+        choices: [
+          "Impedance mismatch and poor return path routing",
+          "Use of low-speed connectors",
+          "Adding extra decoupling capacitors",
+          "Over-specifying power rails"
+        ],
+        answer: 0,
+        explanation: "Impedance mismatches lead to reflections, and poor return paths affect signal quality."
+      },
+      {
+        question: "Which component is essential in converting DC voltages efficiently for processor power rails?",
+        choices: ["Switching regulator", "Linear amplifier", "Level shifter", "Resistor divider"],
+        answer: 0,
+        explanation: "Switching regulators offer high-efficiency DC-DC conversion for power delivery."
+      },
+      {
+        question: "Which protocol is typically used for debugging or serial communication with microcontrollers?",
+        choices: ["UART", "DDR", "MIPI CSI", "Ethernet PHY"],
+        answer: 0,
+        explanation: "UART is commonly used for low-speed serial communication and firmware debugging."
+      },
+      {
+        question: "Why is thermal management critical in high-speed board design?",
+        choices: [
+          "To prevent overheating and ensure reliable performance of dense ICs",
+          "To improve analog input sensitivity",
+          "To synchronize bus latency",
+          "To reduce voltage overshoot on signals"
+        ],
+        answer: 0,
+        explanation: "High-speed components generate heat that must be dissipated to maintain function and lifespan."
+      },
+      {
+        question: "Which of the following tools is used for analyzing frequency domain behavior of high-speed interfaces?",
+        choices: ["Network analyzer", "Multimeter", "Logic analyzer", "Function generator"],
+        answer: 0,
+        explanation: "Network analyzers measure S-parameters and frequency response characteristics."
+      },
+      {
+        question: "What does 'EMC' refer to in PCB design?",
+        choices: [
+          "Electromagnetic compatibility — the ability of a device to function properly without emitting or being affected by EMI",
+          "Electromechanical contact resistance",
+          "Energy management controller",
+          "Embedded multi-core controller"
+        ],
+        answer: 0,
+        explanation: "EMC ensures the device does not interfere with or suffer from electromagnetic emissions."
+      },
+      {
+        question: "Which of the following would likely be found on a high-speed AI accelerator board?",
+        choices: [
+          "DDR memory, SerDes interfaces, and power management ICs",
+          "Potentiometers and 7-segment displays",
+          "Vacuum tubes and audio amplifiers",
+          "Pure analog signal chains"
+        ],
+        answer: 0,
+        explanation: "High-speed compute boards need fast memory, high-speed I/O, and advanced power delivery."
+      },
+      {
+        question: "What is the function of a BERT in high-speed testing?",
+        choices: [
+          "Bit Error Rate Tester — used to evaluate signal quality over a link",
+          "Buffered Edge Routing Timer",
+          "Basic Electrical Resistance Tool",
+          "Bus Expansion Register Table"
+        ],
+        answer: 0,
+        explanation: "BERTs measure how reliably a digital link transmits data under real-world conditions."
+      },
+      {
+        question: "What does signal de-embedding accomplish in signal integrity testing?",
+        choices: [
+          "It removes fixture or probe effects to accurately measure the DUT (Device Under Test)",
+          "It removes power supply noise from the data stream",
+          "It isolates ground loops from logic errors",
+          "It enables firmware decryption for link debugging"
+        ],
+        answer: 0,
+        explanation: "De-embedding ensures measurement reflects the true signal at the target component."
+      },
+      {
+        question: "Why is via stub removal important in high-speed designs?",
+        choices: [
+          "Stubs reflect signals, introducing distortion and loss at high frequencies",
+          "They help ground analog reference planes",
+          "They increase power handling capacity",
+          "They isolate power from clock domains"
+        ],
+        answer: 0,
+        explanation: "Via stubs act as unterminated transmission lines, degrading signal quality at high speed."
+      },
+      {
+        question: "What does MIPI typically refer to in high-speed system design?",
+        choices: [
+          "A set of interface standards for cameras and displays",
+          "Memory interleaving protocols for DRAM",
+          "Motor integrated phase inverter",
+          "Machine intelligence power isolation"
+        ],
+        answer: 0,
+        explanation: "MIPI (Mobile Industry Processor Interface) standards define high-speed serial interfaces for sensors and displays."
+      },
+      {
+        question: "What is an example of a use-case for controlled impedance routing?",
+        choices: [
+          "Routing DDR data lines to match impedance and prevent reflections",
+          "Connecting LED strips for visual debugging",
+          "Interfacing low-frequency UART signals",
+          "Routing VCC traces to bypass capacitors"
+        ],
+        answer: 0,
+        explanation: "Controlled impedance routing ensures reliable signal integrity at high speeds."
+      },
+      {
+        question: "What is the function of a SerDes block in a high-speed system?",
+        choices: [
+          "Serializes and deserializes data for transmission over fewer high-speed lanes",
+          "Generates PWM signals for motor control",
+          "Converts analog audio signals to digital",
+          "Regulates linear power rails"
+        ],
+        answer: 0,
+        explanation: "SerDes blocks convert parallel data to serial for high-speed communication."
+      },
+      {
+        question: "Why is eye height and eye width critical in high-speed signal testing?",
+        choices: [
+          "They represent voltage and timing margin respectively in signal integrity analysis",
+          "They measure thermal coupling between layers",
+          "They control EMI emissions",
+          "They define impedance of differential pairs"
+        ],
+        answer: 0,
+        explanation: "Smaller eye openings indicate poorer signal integrity and reduced noise margins."
+      }
+    ];
+
+    const startScreen = document.getElementById('start-screen');
+    const startBtn = document.getElementById('start-btn');
+    const quizEl = document.getElementById('quiz');
+    const progressEl = document.getElementById('progress');
+    const questionText = document.getElementById('question-text');
+    const choicesEl = document.getElementById('choices');
+    const explanationEl = document.getElementById('explanation');
+    const nextBtn = document.getElementById('next-btn');
+    const resultEl = document.getElementById('result');
+    const scoreEl = document.getElementById('score');
+    const restartBtn = document.getElementById('restart-btn');
+
+    let current = 0;
+    let score = 0;
+
+    startBtn.addEventListener('click', () => {
+      startScreen.classList.add('hidden');
+      quizEl.classList.remove('hidden');
+      current = 0;
+      score = 0;
+      showQuestion();
+    });
+
+    nextBtn.addEventListener('click', () => {
+      current++;
+      if (current >= QUESTIONS.length) {
+        quizEl.classList.add('hidden');
+        resultEl.classList.remove('hidden');
+        scoreEl.textContent = `You scored ${score} out of ${QUESTIONS.length}.`;
+      } else {
+        showQuestion();
+      }
+    });
+
+    restartBtn.addEventListener('click', () => {
+      resultEl.classList.add('hidden');
+      startScreen.classList.remove('hidden');
+    });
+
+    function showQuestion() {
+      const q = QUESTIONS[current];
+      progressEl.textContent = `Question ${current + 1} of ${QUESTIONS.length}`;
+      questionText.textContent = q.question;
+      choicesEl.innerHTML = '';
+      q.choices.forEach((choice, idx) => {
+        const btn = document.createElement('button');
+        btn.className = 'w-full text-left px-4 py-2 rounded bg-black/40 hover:bg-accent-blue/20 transition-colors';
+        btn.innerHTML = `<span class="font-medium mr-2">${String.fromCharCode(65 + idx)}.</span>${choice}`;
+        btn.addEventListener('click', () => selectAnswer(idx));
+        choicesEl.appendChild(btn);
+      });
+      explanationEl.classList.add('hidden');
+      explanationEl.textContent = '';
+      nextBtn.classList.add('hidden');
+    }
+
+    function selectAnswer(idx) {
+      const q = QUESTIONS[current];
+      const correct = idx === q.answer;
+      Array.from(choicesEl.children).forEach((btn, i) => {
+        if (i === q.answer) {
+          btn.classList.add('bg-green-600');
+        }
+        if (i === idx && !correct) {
+          btn.classList.add('bg-red-600');
+        }
+        btn.disabled = true;
+      });
+      if (correct) score++;
+      explanationEl.innerHTML = (correct ? '<span class="text-green-400 font-semibold">Correct.</span> ' : '<span class="text-red-400 font-semibold">Incorrect.</span> ') + q.explanation;
+      explanationEl.classList.remove('hidden');
+      nextBtn.classList.remove('hidden');
+    }
+  </script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,846 @@
+{
+  "name": "interviewaware",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "interviewaware",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.4.5",
+        "express": "^4.18.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No tests\" && exit 0"
+    "test": "echo \"No tests\" && exit 0",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "dotenv": "^16.4.5",
     "express": "^4.18.2"
   },
   "keywords": [],

--- a/questions/question1.html
+++ b/questions/question1.html
@@ -68,6 +68,8 @@
           <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
         </div>
       </div>
+      <a href="../interview.html" class="text-gray-300 hover:text-white transition-colors">Interview Quiz</a>
+      <a href="../ai.html" class="text-gray-300 hover:text-white transition-colors">AI Interviewer</a>
     </div>
     <a href="https://forms.gle/8aHq2fjXJQZP2PDN8" class="hidden md:inline-block rounded-full bg-accent-blue text-white px-5 py-2 font-medium hover:bg-opacity-80 transition">Sign Up</a>
   </div>

--- a/questions/question2.html
+++ b/questions/question2.html
@@ -68,6 +68,8 @@
           <span class="block px-4 py-2 text-gray-500">Chemical Engineering (coming soon)</span>
         </div>
       </div>
+      <a href="../interview.html" class="text-gray-300 hover:text-white transition-colors">Interview Quiz</a>
+      <a href="../ai.html" class="text-gray-300 hover:text-white transition-colors">AI Interviewer</a>
     </div>
     <a href="https://forms.gle/8aHq2fjXJQZP2PDN8" class="hidden md:inline-block rounded-full bg-accent-blue text-white px-5 py-2 font-medium hover:bg-opacity-80 transition">Sign Up</a>
   </div>

--- a/scripts/openai-test.js
+++ b/scripts/openai-test.js
@@ -1,0 +1,27 @@
+require('dotenv').config();
+
+async function run() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error('OPENAI_API_KEY not set');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'Hello from CI' }],
+      max_tokens: 5
+    })
+  });
+  const data = await response.json();
+  console.log(JSON.stringify(data, null, 2));
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+require('dotenv').config();
 
 const app = express();
 app.use(express.json());

--- a/server.js
+++ b/server.js
@@ -1,0 +1,33 @@
+const express = require('express');
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/interviewer', async (req, res) => {
+  const { messages } = req.body;
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages
+      })
+    });
+    const data = await response.json();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error communicating with OpenAI' });
+  }
+});
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));
+}
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- rename hardware quiz page to `interview.html` and update navigation
- add AI interviewer chat page backed by OpenAI
- proxy OpenAI requests through Express server using `OPENAI_API_KEY`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689111bf6c5c8320b3668d1f6f6a833d